### PR TITLE
fix: allow all origins in CORS (for now)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,6 @@
 import dotenv
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from .database.connection import init as init_db
 from .routers import admin, auth, locations, offers, users
@@ -7,6 +8,14 @@ from .routers import admin, auth, locations, offers, users
 dotenv.load_dotenv()
 
 app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_headers=["*"],
+    allow_methods=["*"],
+)
 
 
 @app.on_event("startup")


### PR DESCRIPTION
We might later want to restrict this to domains by our websites. But for testing purposes with the frontend, we seem to need this...