### PR TITLE
feat!: allow multiple activity types per location

### DIFF
--- a/backend/database/models/locations.py
+++ b/backend/database/models/locations.py
@@ -48,7 +48,7 @@ class ReviewsSummary(BaseModel):
 
 
 class LocationBase(BaseModel):
-    activity_type: str
+    activity_types: list[str]
     location: GeoJsonLocation
     name: str | None
     trust_score: int

--- a/backend/database/service/locations.py
+++ b/backend/database/service/locations.py
@@ -31,7 +31,7 @@ class LocationService:
         return
 
     def get_activities_filter(self, activities):
-        return In(LocationShortDb.activity_type, activities)
+        return In(LocationShortDb.activity_types, activities)
 
     async def _insert(self, location: LocationDetailedDb):
         loc = await location.insert()

--- a/docs/test_setup/load_sample_data.py
+++ b/docs/test_setup/load_sample_data.py
@@ -14,7 +14,6 @@ sys.path.append("../../")
 
 from backend.database.connection import client
 from backend.database.models.locations import (
-    LocationDetailed,
     LocationDetailedDb,
     LocationShortDb,
     ReviewsSummary,
@@ -98,7 +97,7 @@ def osm_to_mongo(loc):
     loc = munch.DefaultMunch.fromDict(loc)  # easier access in nested dicts
     d = {
         "_schemaVersion": 1,
-        "activity_type": loc.tags.sport,
+        "activity_types": loc.tags.sport.split(";"),
         "location": dict(loc.center),
         "creation": {
             "created_by": LocationCreators.OSM,


### PR DESCRIPTION
in OSM, this is stored with a string that separates the individual types with semicolons