### PR TITLE
feat!: reworking authentication w/ refresh tokens

### DIFF
--- a/backend/database/models/users.py
+++ b/backend/database/models/users.py
@@ -19,6 +19,7 @@ class Authentication(BaseModel):
     type: AuthType
     password_hash: str | None = None
     email: str | None = None
+    refresh_token: str | None = None
     # more optional members to follow
 
 
@@ -28,12 +29,15 @@ class UserWithoutId(UserBase):
     ip_address: IPvAnyAddress | None = None
     creation_date: Datetime
     last_location: GeoJsonLocation | None = None
-    authentication: Authentication
     archived_until: Datetime | None = None
     admin: bool | None = None
 
 
-class User(Document, UserWithoutId):
+class UserWithAuthentication(UserWithoutId):
+    authentication: Authentication
+
+
+class User(Document, UserWithAuthentication):
     id: PydanticObjectId
 
     class Settings:
@@ -45,7 +49,7 @@ class User(Document, UserWithoutId):
         ]
 
 
-class NewUser(Document, UserWithoutId):
+class NewUser(Document, UserWithAuthentication):
     id: PydanticObjectId | None = None
     verification_code: str | None = None
 
@@ -70,6 +74,7 @@ class UserApiIn(UserBase):
 
 class UserDetailed(UserWithoutId):
     id: PydanticObjectId
+    email: str
 
 
 class UserPasswordReset(Document):

--- a/backend/database/service/users.py
+++ b/backend/database/service/users.py
@@ -144,6 +144,17 @@ class UserService:
 
         return True
 
+    async def set_refresh_token(self, user: User, refresh_token: str):
+        user.authentication.refresh_token = refresh_token
+        await user.save()
+
+    async def delete_refresh_token(self, user: User):
+        if user.authentication.refresh_token is None:
+            raise E.UserAlreadyLoggedOut()
+
+        user.authentication.refresh_token = None
+        await user.save()
+
     async def change_password(self, user: User, form: ChangePasswordForm):
         if not verify_password(form.old_password, user.authentication.password_hash):
             raise E.UserWrongPassword()

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1,15 +1,18 @@
 from typing import Annotated
 
 from beanie import PydanticObjectId
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Body, Depends, HTTPException
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from pydantic import BaseModel
 
+import backend.util.errors as errors
 from backend.database.models.users import User
 from backend.database.service import user_service
+from backend.util.constants import REFRESH_TOKEN_EXPIRY_TIME
 from backend.util.crypto import (
-    create_access_token,
+    create_refresh_token,
     decode_session_token,
+    refresh_access_token,
     verify_password,
 )
 
@@ -18,9 +21,13 @@ router = APIRouter(prefix="/auth", tags=["auth"])
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="auth/token")
 
 
-class AuthTokenBody(BaseModel):
+class AccessTokenBody(BaseModel):
     access_token: str
     token_type: str
+
+
+class LoginTokenBody(AccessTokenBody):
+    refresh_token: str
 
 
 async def get_user(id: PydanticObjectId) -> User | None:
@@ -31,7 +38,7 @@ async def get_user_by_name(username: str) -> User | None:
     return await user_service.get_by_username(username)
 
 
-async def get_current_user(token: Annotated[str, Depends(oauth2_scheme)]):
+async def get_current_user(token: Annotated[str, Depends(oauth2_scheme)]) -> User:
     try:
         token_data = decode_session_token(token)
     except:
@@ -44,7 +51,10 @@ async def get_current_user(token: Annotated[str, Depends(oauth2_scheme)]):
     return user
 
 
-async def get_admin(user: Annotated[User, Depends(get_current_user)]):
+ApiUser = Annotated[User, Depends(get_current_user)]
+
+
+async def get_admin(user: ApiUser):
     if user.admin is None or not user.admin:
         raise HTTPException(401, "User not authorized as admin!")
 
@@ -64,12 +74,50 @@ async def authenticate_user(username: str, plain: str) -> User:
 
 
 @router.post("/token")
-async def login(form_data: OAuth2PasswordRequestForm = Depends()) -> AuthTokenBody:
+async def login(form_data: OAuth2PasswordRequestForm = Depends()) -> LoginTokenBody:
     user = await authenticate_user(form_data.username, form_data.password)
 
     if user.archived_until is not None:
         raise HTTPException(403, f"User is archived until {user.archived_until}")
 
-    token = create_access_token(data={"sub": str(user.id)})
+    refresh_token = create_refresh_token(
+        data={"sub": str(user.id)}, expiry_time=REFRESH_TOKEN_EXPIRY_TIME
+    )
 
-    return AuthTokenBody(access_token=token, token_type="bearer")
+    await user_service.set_refresh_token(user, refresh_token)
+
+    token = refresh_access_token(
+        data={"sub": str(user.id)}, refresh_token=refresh_token
+    )
+
+    return LoginTokenBody(
+        access_token=token, refresh_token=refresh_token, token_type="bearer"
+    )
+
+
+@router.post("/refresh")
+async def get_new_access_token(refresh_token: str) -> AccessTokenBody:
+    user = await get_current_user(refresh_token)
+
+    if user.archived_until is not None:
+        raise HTTPException(403, f"User is archived until {user.archived_until}")
+
+    if (
+        user.authentication.refresh_token is None
+        or user.authentication.refresh_token != refresh_token
+    ):
+        raise HTTPException(401, "Token invalid! Login needed!")
+
+    token = refresh_access_token(
+        data={"sub": str(user.id)}, refresh_token=refresh_token
+    )
+
+    return AccessTokenBody(access_token=token, token_type="bearer")
+
+
+@router.post("/logout")
+async def logout(user: ApiUser):
+    try:
+        await user_service.delete_refresh_token(user)
+    except errors.UserAlreadyLoggedOut:
+        raise HTTPException(401, "User logged out already!")

--- a/backend/routers/chats.py
+++ b/backend/routers/chats.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 
 from backend.database.models.users import Message, MessageOut
 from backend.database.service import chat_service, relation_service
-from backend.routers.users import ApiUser
+from backend.routers.auth import ApiUser
 
 router = APIRouter(prefix="/chats", tags=["chats"])
 

--- a/backend/routers/locations.py
+++ b/backend/routers/locations.py
@@ -20,7 +20,7 @@ from backend.database.models.locations import (
 )
 from backend.database.models.shared import PhotoInfo, PhotoUrl
 from backend.database.service import location_service, review_service, user_service
-from backend.routers.users import ApiUser
+from backend.routers.auth import ApiUser
 from backend.util.types import LatitudeCoordinate, LongitudeCoordinate
 
 router = APIRouter(prefix="/locations", tags=["locations"])

--- a/backend/routers/offers.py
+++ b/backend/routers/offers.py
@@ -16,7 +16,7 @@ from backend.database.service import (
     relation_service,
     user_service,
 )
-from backend.routers.users import ApiUser
+from backend.routers.auth import ApiUser
 from backend.util import errors
 from backend.util.types import LatitudeCoordinate, LongitudeCoordinate
 

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -9,7 +9,6 @@ from pydantic import BaseModel
 import backend.util.errors as E
 from backend.database.models.shared import PhotoInfo, PhotoUrl
 from backend.database.models.users import (
-    User,
     UserApiIn,
     UserApiOut,
     UserDetailed,
@@ -17,12 +16,7 @@ from backend.database.models.users import (
     VerifyUserInfo,
 )
 from backend.database.service import relation_service, user_service
-from backend.routers.auth import (
-    authenticate_user,
-    get_current_user,
-    get_user_by_name,
-    login,
-)
+from backend.routers.auth import ApiUser, authenticate_user, get_current_user, login
 from backend.util.crypto import (
     ChangePasswordForm,
     ResetPasswordForm,
@@ -61,12 +55,9 @@ class CreateUserResponse(BaseModel):
     id: PydanticObjectId
 
 
-ApiUser = Annotated[User, Depends(get_current_user)]
-
-
 @me_router.get("/")
 def get_this_user(user: ApiUser) -> UserDetailed:
-    return UserDetailed(**user.dict())
+    return UserDetailed(**user.dict(), email=user.authentication.email)
 
 
 @me_router.delete("/")

--- a/backend/util/constants.py
+++ b/backend/util/constants.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 
 import dotenv
@@ -17,6 +18,7 @@ def get_env_or_throw(v):
 MONGODB_CONNECTION_STRING = get_env_or_throw("MONGODB_CONNECTION_STRING")
 DATABASE_NAME = get_env_or_throw("MONGO_DATABASE_NAME")
 JWT_SECRET_KEY = get_env_or_throw("JWT_SECRET_KEY")
+REFRESH_TOKEN_EXPIRY_TIME = datetime.timedelta(days=30)
 
 DATE_FMT = "%Y-%m-%dT%H:%M:%SZ"
 

--- a/backend/util/crypto.py
+++ b/backend/util/crypto.py
@@ -80,7 +80,15 @@ def decode_token(token: str):
     return token_data
 
 
-def create_access_token(data: dict, expiry_time: timedelta | None = None):
+def create_refresh_token(data: dict, expiry_time: timedelta | None = None):
+    expiry_time = expiry_time or constants.REFRESH_TOKEN_EXPIRY_TIME
+    token, _ = create_token(data, expiry_time)
+    return token
+
+
+def refresh_access_token(
+    data: dict, refresh_token: str, expiry_time: timedelta | None = None
+):
     expiry_time = expiry_time or SESSION_TOKEN_EXPIRE
     token, _ = create_token(data, expiry_time)
     return token

--- a/backend/util/errors.py
+++ b/backend/util/errors.py
@@ -30,6 +30,10 @@ class UsernameAlreadyTaken(Exception):
     ...
 
 
+class UserAlreadyLoggedOut(Exception):
+    ...
+
+
 class EmailDoesNotMatchAccount(Exception):
     ...
 


### PR DESCRIPTION
Upon login, the user will now get an access token and a refresh token. The access token will stay valid for the former 20 minutes. The refresh token is used to generate a new access token and is itself valid for 30 days. Only the refresh token is saved in the database thus reducing frequent checks for the validity of the access token.